### PR TITLE
Allow looking up all the locations for a postcode

### DIFF
--- a/pgeocode.py
+++ b/pgeocode.py
@@ -37,7 +37,10 @@ class Nominatim(object):
     Parameters
     ----------
     country: str, default='fr'
-       country conde. See the documentation for a list of supported countries.
+       country code. See the documentation for a list of supported countries.
+    unique: bool, default=True
+        Create unique postcode index, merging all places with the same postcode
+        into a single entry
     """
     def __init__(self, country='fr', unique=True):
 

--- a/pgeocode.py
+++ b/pgeocode.py
@@ -39,7 +39,7 @@ class Nominatim(object):
     country: str, default='fr'
        country conde. See the documentation for a list of supported countries.
     """
-    def __init__(self, country='fr'):
+    def __init__(self, country='fr', non_unique=False):
 
         country = country.upper()
         if country not in COUNTRIES_VALID:
@@ -53,7 +53,11 @@ class Nominatim(object):
                           "in 1999.")
         self.country = country
         self._data_path, self._data = self._get_data(country)
-        self._data_unique = self._index_postal_codes()
+        if non_unique:
+            self._data_frame = self._data
+        else:
+            self._data_frame = self._index_postal_codes()
+        self.unique = not non_unique
 
     @staticmethod
     def _get_data(country):
@@ -147,9 +151,9 @@ class Nominatim(object):
             codes = pd.DataFrame(codes, columns=['postal_code'])
 
         codes = self._normalize_postal_code(codes)
-        response = pd.merge(codes, self._data_unique, on='postal_code',
+        response = pd.merge(codes, self._data_frame, on='postal_code',
                             how='left')
-        if single_entry:
+        if self.unique and single_entry:
             response = response.iloc[0]
         return response
 

--- a/pgeocode.py
+++ b/pgeocode.py
@@ -39,7 +39,7 @@ class Nominatim(object):
     country: str, default='fr'
        country conde. See the documentation for a list of supported countries.
     """
-    def __init__(self, country='fr', non_unique=False):
+    def __init__(self, country='fr', unique=True):
 
         country = country.upper()
         if country not in COUNTRIES_VALID:
@@ -53,11 +53,11 @@ class Nominatim(object):
                           "in 1999.")
         self.country = country
         self._data_path, self._data = self._get_data(country)
-        if non_unique:
-            self._data_frame = self._data
-        else:
+        if unique:
             self._data_frame = self._index_postal_codes()
-        self.unique = not non_unique
+        else:
+            self._data_frame = self._data
+        self.unique = unique
 
     @staticmethod
     def _get_data(country):

--- a/test_pgeocode.py
+++ b/test_pgeocode.py
@@ -73,10 +73,10 @@ def test_download_dataset(temp_dir):
 
     assert_array_equal(nomi._data.columns,
                        nomi2._data.columns)
-    assert_array_equal(nomi._data_unique.columns,
-                       nomi2._data_unique.columns)
+    assert_array_equal(nomi._data_frame.columns,
+                       nomi2._data_frame.columns)
     assert nomi._data.shape == nomi._data.shape
-    assert nomi._data_unique.shape == nomi._data_unique.shape
+    assert nomi._data_frame.shape == nomi._data_frame.shape
 
     assert len(res.place_name.split(',')) > 1
     assert len(res2.place_name.split(',')) > 1
@@ -100,13 +100,23 @@ def test_nominatim_query_postal_code():
 
 
 def test_nominatim_query_postal_code_multiple():
-    nomi = Nominatim('de', non_unique=True)
+    nomi = Nominatim('de', unique=False)
+    expected_places = [
+        'Wellen',
+        'Groß Rodensleben',
+        'Irxleben',
+        'Eichenbarleben',
+        'Klein Rodensleben',
+        'Niederndodeleben',
+        'Hohendodeleben',
+        'Ochtmersleben',
+    ]
 
     res = nomi.query_postal_code('39167')
     assert isinstance(res, pd.DataFrame)
-    assert res.shape[0] == 8
-    assert res.place_name.values[0] == 'Eichenbarleben'
-    assert res.place_name.values[7] == 'Ochtmersleben'
+    assert res.shape[0] == len(expected_places)
+    for place in res.place_name.values:
+        assert place in expected_places
 
 
 def test_nominatim_distance_postal_code():

--- a/test_pgeocode.py
+++ b/test_pgeocode.py
@@ -99,6 +99,16 @@ def test_nominatim_query_postal_code():
     assert not np.isfinite(res.iloc[2].latitude)
 
 
+def test_nominatim_query_postal_code_multiple():
+    nomi = Nominatim('de', non_unique=True)
+
+    res = nomi.query_postal_code('39167')
+    assert isinstance(res, pd.DataFrame)
+    assert res.shape[0] == 8
+    assert res.place_name.values[0] == 'Eichenbarleben'
+    assert res.place_name.values[7] == 'Ochtmersleben'
+
+
 def test_nominatim_distance_postal_code():
 
     gdist = GeoDistance('fr')

--- a/test_pgeocode.py
+++ b/test_pgeocode.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 # License 3-clause BSD
 #
 # Authors: Roman Yurchak <roman.yurchak@symerio.com>


### PR DESCRIPTION
Normally all the places under single postcode are merged in comma separated list.
This adds non_unique parameter to the constructor which returns all locations per postcode, without squashing them into comma separated list.

The default value for the non_unique parameter is chosen so it doesn't change the current behaviour.