### PR TITLE
Fix reading Canadian postal code

### DIFF
--- a/pgeocode.py
+++ b/pgeocode.py
@@ -122,7 +122,7 @@ class Nominatim(object):
         elif self.country == 'IE':
             codes['postal_code'] = codes.postal_code.str.split().str.get(0)
         elif self.country == 'CA':
-            codes['postal_code'] = codes.postal_code.str.split().str.get(1)
+            codes['postal_code'] = codes.postal_code.str.split().str.get(0)
         else:
             pass
 

--- a/pgeocode.py
+++ b/pgeocode.py
@@ -117,11 +117,7 @@ class Nominatim(object):
         """
         codes['postal_code'] = codes.postal_code.str.upper()
 
-        if self.country == 'GB':
-            codes['postal_code'] = codes.postal_code.str.split().str.get(0)
-        elif self.country == 'IE':
-            codes['postal_code'] = codes.postal_code.str.split().str.get(0)
-        elif self.country == 'CA':
+        if self.country in ['GB', 'IE', 'CA']:
             codes['postal_code'] = codes.postal_code.str.split().str.get(0)
         else:
             pass

--- a/test_pgeocode.py
+++ b/test_pgeocode.py
@@ -41,7 +41,7 @@ def _normalize_str(x):
          ('AU', '6837', 'Perth', '3000', 'melbourne', 2722),
          ('AU', '6837', 'Perth', '0221', 'Barton', 3089),
          ('US', '60605', 'Chicago', '94103', 'San Francisco', 2984),
-         ('CA', 'ON M5R 1X8', 'Toronto', 'QC H2Z 1A7', 'Montreal', 503),
+         ('CA', 'M5R 1X8', 'Toronto', 'H2Z 1A7', 'Montreal', 503),
          ('IE', 'D01 R2PO', 'Dublin', 'T12 RW26', 'Cork', 219),
          ])
 def test_countries(country, pc1, location1, pc2, location2,


### PR DESCRIPTION
Closes https://github.com/symerio/pgeocode/issues/10


https://en.wikipedia.org/wiki/Postal_codes_in_Canada

Canadian postal code has the format like 'K1A 0B1'. Only the first three characters were used for getting the latitude and longitude. 