### PR TITLE
MAINT Drop Python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 
 matrix:
   include:
-    - python: 2.7
-      env: REQUIREMENTS="numpy pandas pytest"
     - python: 3.5
       env: REQUIREMENTS="numpy pandas==0.22 pytest"
     - python: 3.6

--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,11 @@ Intended Audience :: Science/Research
 Intended Audience :: Developers
 License :: OSI Approved :: BSD License
 Programming Language :: Python
-Programming Language :: Python :: 2
-Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
 Topic :: Software Development
 Operating System :: POSIX
 Operating System :: Unix


### PR DESCRIPTION
Drop Python 2.7 support that reached EOL in at the end of the month.

The next release will be Python 3.5+ only.