### PR TITLE
corrected inconsistent name in 'country code' column name

### DIFF
--- a/pgeocode.py
+++ b/pgeocode.py
@@ -19,7 +19,7 @@ STORAGE_DIR = os.environ.get(
 
 DOWNLOAD_URL = "https://download.geonames.org/export/zip/{country}.zip"
 
-DATA_FIELDS = ['country code', 'postal_code', 'place_name',
+DATA_FIELDS = ['country_code', 'postal_code', 'place_name',
                'state_name', 'state_code', 'county_name', 'county_code',
                'community_name', 'community_code',
                'latitude', 'longitude', 'accuracy']

--- a/test_pgeocode.py
+++ b/test_pgeocode.py
@@ -55,6 +55,8 @@ def test_countries(country, pc1, location1, pc2, location2,
     assert isinstance(res, pd.Series)
     assert _normalize_str(location1) in _normalize_str(res.place_name)
 
+    assert isinstance(res, pd.Series)
+
     res = nomi.query_postal_code(pc2)
     assert isinstance(res, pd.Series)
     assert _normalize_str(location2) in _normalize_str(res.place_name)

--- a/test_pgeocode.py
+++ b/test_pgeocode.py
@@ -55,7 +55,7 @@ def test_countries(country, pc1, location1, pc2, location2,
     assert isinstance(res, pd.Series)
     assert _normalize_str(location1) in _normalize_str(res.place_name)
 
-    assert isinstance(res, pd.Series)
+    assert 'country_code' in res.index
 
     res = nomi.query_postal_code(pc2)
     assert isinstance(res, pd.Series)


### PR DESCRIPTION
https://github.com/symerio/pgeocode/issues/33

Test run before any change

```
======================================================================================= test session starts ========================================================================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/dhynes/fix/pgeocode
collected 95 items

test_pgeocode.py ......x...sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss.s                                                                             [100%]

============================================================================ 10 passed, 84 skipped, 1 xfailed in 42.45s ============================================================================
```

updated the column to use an underscore and re-tested

```
======================================================================================= test session starts ========================================================================================
platform linux -- Python 3.6.8, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/dhynes/fix/pgeocode
collected 95 items

test_pgeocode.py ......x...sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss.s                                                                             [100%]

============================================================================ 10 passed, 84 skipped, 1 xfailed in 14.18s ============================================================================
```

The other error at the very end of the description on that Issue seems to be one thats outside of the scope of this I think so I didn't address it as that would probably involve changing how errors are handled.