### PR TITLE
Add fallback mechanism for data sources

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -38,5 +38,5 @@ jobs:
         pip install flake8
     - name: Test with pytest
       run: |
-        pip install pytest
+        pip install pytest pytest-httpserver
         pytest

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
 
     steps:
     - uses: actions/checkout@v2
@@ -25,6 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         if [ ${{ matrix.python-version }} == 3.6 ]
         then
+           # for other python versions the latest pandas and numpy versions are tested
            pip install numpy==1.13.3 pandas==0.25
         elif [ ${{ matrix.python-version }} == 'pypy3' ]
         then

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: [3.6, 3.7, 3.8, pypy3]
 
     steps:
     - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8
@@ -15,7 +15,7 @@ repos:
     -   id: flake8
         types: [file, python]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.730
+    rev: v0.790
     hooks:
      -  id: mypy
         args:

--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,27 @@ Defaults to ``~/pgeocode_data``, it is the directory where data is downloaded
 for later consumption. It can be changed using the environment variable
 ``PGEOCODE_DATA_DIR``, i.e. ``export PGEOCODE_DATA_DIR=/tmp/pgeocode_data``.
 
+**Data sources**
+
+The data sources are provided as a list in the ``pgeocode.DOWNLOAD_URL`` variable.
+The default value is,
+
+.. code::
+
+    DOWNLOAD_URL = [
+        "https://download.geonames.org/export/zip/{country}.zip",
+        "https://symerio.github.io/postal-codes-data/data/geonames/{country}.txt",
+    ]
+
+Data sources are tried from first to last until one works. Here the second link is a mirror
+of the first.
+
+It is also possible to extend this variable with third party data sources, as
+long as they follow the same format. See for instance
+[postal-codes-data](https://github.com/symerio/postal-codes-data/tree/master/data/geonames)
+repository for examples of data files.
+
+
 License
 -------
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -11,6 +11,10 @@ Unit tests can be run with,
 
 .. code::
 
+    pip install pytest pytest-httpserver
+
+.. code::
+
     pytest
 
 Code style

--- a/pgeocode.py
+++ b/pgeocode.py
@@ -172,7 +172,6 @@ def _open_extract_cycle_url(urls: List[str], country: str) -> Any:
                 "Trying next URL in DOWNLOAD_URL list.",
                 UserWarning,
             )
-            continue
     else:
         raise ValueError(err_msg)
 

--- a/test_pgeocode.py
+++ b/test_pgeocode.py
@@ -2,8 +2,10 @@
 #
 # Authors: Roman Yurchak <roman.yurchak@symerio.com>
 import os
-import shutil
-import tempfile
+import urllib
+import json
+from zipfile import ZipFile
+from io import BytesIO
 
 import numpy as np
 import pandas as pd
@@ -12,16 +14,13 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 import pgeocode
 from pgeocode import GeoDistance, Nominatim, haversine_distance
+from pgeocode import _open_extract_url
 
 
 @pytest.fixture
-def temp_dir():
-    path_save = pgeocode.STORAGE_DIR
-    path = tempfile.mkdtemp()
-    pgeocode.STORAGE_DIR = path
-    yield path
-    pgeocode.STORAGE_DIR = path_save
-    shutil.rmtree(path)
+def temp_dir(tmpdir, monkeypatch):
+    monkeypatch.setattr(pgeocode, "STORAGE_DIR", str(tmpdir))
+    yield str(tmpdir)
 
 
 def _normalize_str(x):
@@ -179,3 +178,61 @@ def test_haversine_distance():
     d_pred = haversine_distance(x, y)
     # same distance +/- 3 km
     assert_allclose(d_ref, d_pred, atol=3)
+
+
+def test_open_extract_url(httpserver):
+    download_url = "/fr.txt"
+
+    # check download of uncompressed files
+    httpserver.expect_oneshot_request(download_url).respond_with_json({"a": 1})
+    with _open_extract_url(httpserver.url_for(download_url), "fr") as fh:
+        assert json.loads(fh.read()) == {"a": 1}
+    httpserver.check_assertions()
+
+    # check download of zipped files
+    # Create an in-memory zip file
+    answer = b"a=1"
+    with BytesIO() as fh:
+        with ZipFile(fh, "w") as fh_zip:
+            with fh_zip.open("FR.txt", "w") as fh_inner:
+                fh_inner.write(answer)
+        fh.seek(0)
+        res = fh.read()
+
+    download_url = "/fr.zip"
+    httpserver.expect_oneshot_request(download_url).respond_with_data(res)
+
+    with _open_extract_url(httpserver.url_for(download_url), "fr") as fh:
+        assert fh.read() == answer
+
+
+@pytest.mark.parametrize(
+    "download_url",
+    [
+        "https://download.geonames.org/export/zip/{country}.zip",
+        "https://symerio.github.io/postal-codes-data/data/"
+        "geonames/{country}.txt",
+    ],
+    ids=["geonames", "gitlab-pages"],
+)
+def test_cdn(temp_dir, monkeypatch, download_url):
+    monkeypatch.setattr(pgeocode, "DOWNLOAD_URL", [download_url])
+    assert not os.path.exists(os.path.join(temp_dir, "IE.txt"))
+    Nominatim("IE")
+    # the data file was downloaded
+    assert os.path.exists(os.path.join(temp_dir, "IE.txt"))
+
+
+def test_url_returns_404(httpserver, monkeypatch, temp_dir):
+    download_url = "/fr.gzip"
+    httpserver.expect_oneshot_request(download_url).respond_with_data(
+        "", status=404
+    )
+
+    monkeypatch.setattr(
+        pgeocode, "DOWNLOAD_URL", [httpserver.url_for(download_url)]
+    )
+    # Nominatim("fr")
+    with pytest.raises(urllib.error.HTTPError, match="HTTP Error 404"):
+        Nominatim("fr")
+    httpserver.check_assertions()


### PR DESCRIPTION
Closes #8 Closes #41, Closes #44 

This adds a fallback mechanism for data sources, in case the main GeoNames server is temporarly not available.
By default the secondary fallback URL is a mirror on GitHub https://symerio.github.io/postal-codes-data/

This also adds support for data sources with plain (non zipped) .txt files. 