### PR TITLE
tox tests

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,11 +20,11 @@
 import os
 import sys
 
-import pgeocode
-from typing import Any
-
 sys.path.insert(0, os.path.abspath("../"))
 sys.path.insert(0, os.path.abspath("sphinxext"))
+
+import pgeocode  # noqa
+from typing import Any  # noqa
 
 from github_link import make_linkcode_resolve  # noqa
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -17,6 +17,8 @@ Unit tests can be run with,
 
     pytest
 
+You can also run ``tox`` to run the unit test will all the supported python versions.
+
 Code style
 ----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,29 @@ requires = ["setuptools>=42", "wheel"]
 
 [tool.black]
 line-length = 79
+
+[tool.tox]
+legacy_tox_ini = """
+[tox]
+isolated_build = true
+envlist = doc,py36,py37,py38,py39,coverage
+skipsdist=true
+
+[testenv]
+whitelist_externals = poetry
+commands =
+    pip install --editable . pytest pytest-httpserver
+    pytest {posargs}
+
+[testenv:doc]
+commands =
+    pip install --editable .
+    pip install --requirement doc/requirements.txt
+    sphinx-build doc build/sphinx/html
+
+[testenv:coverage]
+commands =
+    pip install --editable . pytest pytest-httpserver coverage
+    coverage run -m pytest {posargs}
+    coverage html
+"""


### PR DESCRIPTION
This patch adds a basic configuration to run the tests on all the supported python versions with tox.
This avoids having to push and let GHA tests for all those versions.
This also provides coverage tests and builds the documentation.