### PR TITLE
Change default folder to .pgeocode_data

### DIFF
--- a/pgeocode.py
+++ b/pgeocode.py
@@ -16,7 +16,8 @@ import pandas as pd
 __version__ = "0.3.0"
 
 STORAGE_DIR = os.environ.get(
-    "PGEOCODE_DATA_DIR", os.path.join(os.path.expanduser("~"), "pgeocode_data")
+    "PGEOCODE_DATA_DIR",
+    os.path.join(os.path.expanduser("~"), ".pgeocode_data"),
 )
 
 # A list of download locations. If the first URL fails, following ones will


### PR DESCRIPTION
This is mostly for unix-like environments. By having the folder starting with a dot will make the folder hidden. I dislike having a load of folders in my home directory and this hides it away.