### PR TITLE
Add try/except around STORAGE_DIR creation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -184,7 +184,7 @@ texinfo_documents = [
 # The following is used by sphinx.ext.linkcode to provide links to github
 linkcode_resolve = make_linkcode_resolve(
     "pgeocode",
-    u"https://github.com/symerio/"
+    "https://github.com/symerio/"
     "pgeocode/blob/{revision}/"
     "{package}/{path}#L{lineno}",
 )

--- a/pgeocode.py
+++ b/pgeocode.py
@@ -232,17 +232,13 @@ class Nominatim:
                     names=DATA_FIELDS,
                     dtype={"postal_code": str},
                 )
-            if not os.path.exists(STORAGE_DIR):
-                try:
-                    os.mkdir(STORAGE_DIR)
-                except FileExistsError:
-                    pass
+            os.makedirs(STORAGE_DIR, exist_ok=True)
             data.to_csv(data_path, index=None)
 
         return data_path, data
 
     def _index_postal_codes(self) -> pd.DataFrame:
-        """ Create a dataframe with unique postal codes """
+        """Create a dataframe with unique postal codes"""
         data_path_unique = self._data_path.replace(".txt", "-index.txt")
 
         if os.path.exists(data_path_unique):

--- a/pgeocode.py
+++ b/pgeocode.py
@@ -233,7 +233,10 @@ class Nominatim:
                     dtype={"postal_code": str},
                 )
             if not os.path.exists(STORAGE_DIR):
-                os.mkdir(STORAGE_DIR)
+                try:
+                    os.mkdir(STORAGE_DIR)
+                except FileExistsError:
+                    pass
             data.to_csv(data_path, index=None)
 
         return data_path, data


### PR DESCRIPTION
When instantiating the GeoDistance class at the same time in parallel, there's a chance for the STORAGE_DIR to be created in a separate process between the check and the creation which raises a FileExistsError.

This simply adds a try/except around the `os.mkdir(STORAGE_DIR)` command to protect against this case.