### PR TITLE
Add default var for download url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,9 @@ The default value is,
 Data sources are tried from first to last until one works. Here the second link is a mirror
 of the first.
 
+It can be changed using the environment variable
+``PGEOCODE_DOWNLOAD_URL``, i.e. ``export PGEOCODE_DOWNLOAD_URL=file:///opt/pgeocode_files/{country}.txt``.
+
 It is also possible to extend this variable with third party data sources, as
 long as they follow the same format. See for instance
 `postal-codes-data <https://github.com/symerio/postal-codes-data/tree/master/data/geonames>`_

--- a/pgeocode.py
+++ b/pgeocode.py
@@ -13,7 +13,7 @@ from zipfile import ZipFile
 import numpy as np
 import pandas as pd
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 STORAGE_DIR = os.environ.get(
     "PGEOCODE_DATA_DIR", os.path.join(os.path.expanduser("~"), "pgeocode_data")
@@ -21,10 +21,11 @@ STORAGE_DIR = os.environ.get(
 
 # A list of download locations. If the first URL fails, following ones will
 # be used.
-DOWNLOAD_URL = [
+DEFAULT_DOWNLOAD_URL = [
     "https://download.geonames.org/export/zip/{country}.zip",
     "https://symerio.github.io/postal-codes-data/data/geonames/{country}.txt",
 ]
+DOWNLOAD_URL = os.environ.get('PGEOCODE_DOWNLOAD_URL') or DEFAULT_DOWNLOAD_URL
 
 
 DATA_FIELDS = [

--- a/pgeocode.py
+++ b/pgeocode.py
@@ -25,7 +25,7 @@ DEFAULT_DOWNLOAD_URL = [
     "https://download.geonames.org/export/zip/{country}.zip",
     "https://symerio.github.io/postal-codes-data/data/geonames/{country}.txt",
 ]
-DOWNLOAD_URL = os.environ.get('PGEOCODE_DOWNLOAD_URL') or DEFAULT_DOWNLOAD_URL
+DOWNLOAD_URL = os.environ.get("PGEOCODE_DOWNLOAD_URL") or DEFAULT_DOWNLOAD_URL
 
 
 DATA_FIELDS = [


### PR DESCRIPTION
Add usage value of PGEOCODE_DOWNLOAD_URL environment variable as DOWNLOAD_URL.
If variable does not exist, DOWNLOAD_URL is set up as was until now, with default web-links.