### PR TITLE
Fix Nominatim.query_location when query column contains NaN

### DIFF
--- a/pgeocode.py
+++ b/pgeocode.py
@@ -369,6 +369,7 @@ class Nominatim:
 
     def _str_contains_search(self, text: str, col: str) -> pd.DataFrame:
         match_mask = self._data[col].str.lower().str.contains(text.lower())
+        match_mask.fillna(False, inplace=True)
         return self._data[match_mask]
 
     def _fuzzy_search(

--- a/test_pgeocode.py
+++ b/test_pgeocode.py
@@ -273,6 +273,11 @@ def test_query_location_exact():
     assert isinstance(res, pd.DataFrame)
     assert len(res) == 0
 
+    # Query on a different field name
+    res = nomi.query_location("île", col="state_name")
+    assert isinstance(res, pd.DataFrame)
+    assert res["state_name"].unique().tolist() == ["Île-de-France"]
+
 
 def test_query_location_fuzzy():
     pytest.importorskip("thefuzz")


### PR DESCRIPTION
A follow up on https://github.com/symerio/pgeocode/pull/59